### PR TITLE
[wip] Add default implementation for `instanceClone` 

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ var forOwn = require('for-own');
  */
 
 function cloneDeep(val, instanceClone) {
+  instanceClone = instanceClone || defaultInstanceClone;
+
   switch (typeOf(val)) {
     case 'object':
       return cloneObjectDeep(val, instanceClone);
@@ -48,8 +50,8 @@ function cloneArrayDeep(arr, instanceClone) {
   return res;
 }
 
-/**
- * Expose `cloneDeep`
- */
+function defaultInstanceClone(instance) {
+  return Object.create(Object.getPrototypeOf(instance), cloneDeep(Object.getOwnPropertyDescriptors(instance)));
+}
 
 module.exports = cloneDeep;

--- a/test.js
+++ b/test.js
@@ -46,4 +46,27 @@ describe('cloneDeep()', function() {
   it('should clone objects', function() {
     assert.deepEqual(clone({a: 1, b: 2, c: 3 }), {a: 1, b: 2, c: 3 });
   });
+
+  it('should deep clone instances', function() {
+    function A(x, y, z) {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+    }
+
+    function B(x) {
+      this.x = x;
+    }
+
+    var a = new A({x: 11, y: 12, z: () => 'z'}, new B(2), 7);
+    var b = clone(a);
+
+    assert.deepEqual(a, b);
+
+    b.y.x = 1;
+    b.z = 2;
+    assert.notDeepEqual(a, b);
+    assert.notEqual(a.z, b.z, 'Root property of original object not expected to be changed');
+    assert.notEqual(a.y.x, b.y.x, 'Nested property of original object not expected to be changed');
+  });
 });


### PR DESCRIPTION
I use this lib to clone mongoose docs. And unfortunately, cloning goes into infinite loop with this implementation :(.
Not sure if this is a good idea to merge this PR. Unless, you know how to deal with this. I can provide test case, if needed.