### PR TITLE
Avoid recalculate typeof value

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,36 +8,34 @@ const clone = require('shallow-clone');
 const typeOf = require('kind-of');
 
 function cloneDeep(val, instanceClone) {
-  switch (typeOf(val)) {
+  const type = typeOf(val)
+
+  switch (type) {
     case 'object':
-      return cloneObjectDeep(val, instanceClone);
+      return cloneObjectDeep(val, instanceClone, type);
     case 'array':
       return cloneArrayDeep(val, instanceClone);
-    default: {
+    default:
       return clone(val);
-    }
   }
 }
 
-function cloneObjectDeep(val, instanceClone) {
-  if (typeof instanceClone === 'function') {
-    return instanceClone(val);
+function cloneObjectDeep(val, instanceClone, type) {
+  switch (type) {
+    case 'function':
+      return instanceClone(val);
+    case 'object':
+      const res = new val.constructor();
+      for (const key in val) res[key] = cloneDeep(val[key], instanceClone);
+      return res;
+    default:
+      return val;
   }
-  if (typeOf(val) === 'object') {
-    const res = new val.constructor();
-    for (const key in val) {
-      res[key] = cloneDeep(val[key], instanceClone);
-    }
-    return res;
-  }
-  return val;
 }
 
 function cloneArrayDeep(val, instanceClone) {
   const res = new val.constructor(val.length);
-  for (let i = 0; i < val.length; i++) {
-    res[i] = cloneDeep(val[i], instanceClone);
-  }
+  for (let i = 0; i < val.length; i++) res[i] = cloneDeep(val[i], instanceClone);
   return res;
 }
 

--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ function cloneDeep(val, instanceClone) {
 }
 
 function cloneCollection(val, instanceClone) {
-    const res = new val.constructor();
-    for (const key in val) res[key] = cloneDeep(val[key], instanceClone);
-    return res;
+  const res = new val.constructor();
+  for (const key in val) res[key] = cloneDeep(val[key], instanceClone);
+  return res;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -9,13 +9,15 @@ const typeOf = require('kind-of');
 
 const TYPES_COLLECTION = ['object', 'array']
 
-function cloneDeep(val, instanceClone) {
-  return TYPES_COLLECTION.includes(typeOf(val)) ? cloneCollection(val, instanceClone) : clone(val);
+function cloneDeep(val) {
+  return TYPES_COLLECTION.includes(typeOf(val)) ? cloneCollection(val) : clone(val);
 }
 
-function cloneCollection(val, instanceClone) {
+function cloneCollection(val) {
   const res = new val.constructor();
-  for (const key in val) res[key] = cloneDeep(val[key], instanceClone);
+  for (const key in val) {
+    res[key] = cloneDeep(val[key]);
+  }
   return res;
 }
 

--- a/index.js
+++ b/index.js
@@ -7,16 +7,17 @@
 const clone = require('shallow-clone');
 const typeOf = require('kind-of');
 
-const TYPES_COLLECTION = ['object', 'array']
+const TYPES_COLLECTION = ['object', 'array'];
 
-function cloneDeep(val) {
-  return TYPES_COLLECTION.includes(typeOf(val)) ? cloneCollection(val) : clone(val);
+function cloneDeep(val, fn) {
+  return TYPES_COLLECTION.includes(typeOf(val)) ? cloneCollection(val, fn) : clone(val);
 }
 
 function cloneCollection(val) {
+  if (typeof instanceClone === 'function') return instanceClone(val);
   const res = new val.constructor();
   for (const key in val) {
-    res[key] = cloneDeep(val[key]);
+    res[key] = cloneDeep(val[key], instanceClone);
   }
   return res;
 }

--- a/index.js
+++ b/index.js
@@ -7,36 +7,16 @@
 const clone = require('shallow-clone');
 const typeOf = require('kind-of');
 
+const TYPES_COLLECTION = ['object', 'array']
+
 function cloneDeep(val, instanceClone) {
-  const type = typeOf(val)
-
-  switch (type) {
-    case 'object':
-      return cloneObjectDeep(val, instanceClone, type);
-    case 'array':
-      return cloneArrayDeep(val, instanceClone);
-    default:
-      return clone(val);
-  }
+  return TYPES_COLLECTION.includes(typeOf(val)) ? cloneCollection(val, instanceClone) : clone(val);
 }
 
-function cloneObjectDeep(val, instanceClone, type) {
-  switch (type) {
-    case 'function':
-      return instanceClone(val);
-    case 'object':
-      const res = new val.constructor();
-      for (const key in val) res[key] = cloneDeep(val[key], instanceClone);
-      return res;
-    default:
-      return val;
-  }
-}
-
-function cloneArrayDeep(val, instanceClone) {
-  const res = new val.constructor(val.length);
-  for (let i = 0; i < val.length; i++) res[i] = cloneDeep(val[i], instanceClone);
-  return res;
+function cloneCollection(val, instanceClone) {
+    const res = new val.constructor();
+    for (const key in val) res[key] = cloneDeep(val[key], instanceClone);
+    return res;
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -96,4 +96,20 @@ describe('cloneDeep()', function() {
     assert.notEqual(a.z, b.z, 'Root property of original object not expected to be changed');
     assert.notEqual(a.y.x, b.y.x, 'Nested property of original object not expected to be changed');
   });
+
+  it('should deep clone functions', function () {
+    function fn () {
+      return 'hello world'
+    }
+
+    fn.foo = 'bar'
+
+    const target = { fn }
+    const copy = clone(target)
+
+    assert.deepStrictEqual(target, copy)
+    assert.deepStrictEqual(typeof copy.fn, 'function')
+    assert.deepStrictEqual(copy.fn.foo, 'bar')
+  })
+
 });


### PR DESCRIPTION
I noted that `typeOf(val)` was calculated multiple times in the same iteration and actually it can be avoided.

Also I removed redundant code because `for in` can be used for iterate over array