### PR TITLE
Corrects type checking for regural expressions (cloneDeep)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const typeOf = require('kind-of');
 function cloneDeep(val, instanceClone) {
   switch (typeOf(val)) {
     case 'object':
+    case 'regexp':
       return cloneObjectDeep(val, instanceClone);
     case 'array':
       return cloneArrayDeep(val, instanceClone);


### PR DESCRIPTION
Hello, Jon!

I've catched error, when tried to clone `regexp` on my project via `clone-deep`. I made some workaround, add one more checking to `switch` construction. It helped me. If I understand correctly - build-in operator `typeof` returns `"object"` for instances of RegExp, while `kind-of` returns `"regexp"` for such case.

Best regards!