### PR TITLE
FIX - IE11 does not support const inside for...in loops

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function cloneObjectDeep(val, instanceClone) {
   }
   if (typeOf(val) === 'object') {
     const res = new val.constructor();
-    for (const key in val) {
+    for (let key in val) {
       res[key] = cloneDeep(val[key], instanceClone);
     }
     return res;


### PR DESCRIPTION
Proposed fix for issue #15 - https://github.com/jonschlinkert/clone-deep/issues/15

IE11 does not support `const` inside `for...in` loops, so updated it in `cloneObjectDeep` to use `let` instead.

`npm test` still seems to pass

Thanks!

Support reference: http://kangax.github.io/compat-table/es6/