### PR TITLE
Bump kind-of version for CVE-2019-20149

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "is-plain-object": "^2.0.4",
-    "kind-of": "^6.0.2",
+    "kind-of": "^6.0.3",
     "shallow-clone": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Due to [CVE-2019-20149](https://nvd.nist.gov/vuln/detail/CVE-2019-20149), a new version of kind-of has been released.

Since clone-deep uses 6.0.2, this raises security flags.

FYI @jonschlinkert @doowb could you take care of this and release a new version of this package?
