### PR TITLE
Upgrade kind-of to 6.0.3 for CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "is-plain-object": "^2.0.4",
-    "kind-of": "^6.0.2",
+    "kind-of": "^6.0.3",
     "shallow-clone": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clone-deep",
   "description": "Recursively (deep) clone JavaScript native types, like Object, Array, RegExp, Date as well as primitives.",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "homepage": "https://github.com/jonschlinkert/clone-deep",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "jonschlinkert/clone-deep",


### PR DESCRIPTION
The use of the kind-of dependency prior to version 6.0.3 has a security vulnerability. Further details can be found here - https://nvd.nist.gov/vuln/detail/CVE-2019-20149.