### PR TITLE
enable cloning objects without constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 
 const clone = require('shallow-clone');
 const typeOf = require('kind-of');
-const isPlainObject = require('is-plain-object');
+const { isPlainObject } = require('is-plain-object');
 
 function cloneDeep(val, instanceClone) {
   switch (typeOf(val)) {
@@ -25,7 +25,7 @@ function cloneObjectDeep(val, instanceClone) {
     return instanceClone(val);
   }
   if (instanceClone || isPlainObject(val)) {
-    const res = new val.constructor();
+    const res = (val.constructor !== undefined) ? new val.constructor() : Object.create(null);
     for (let key in val) {
       res[key] = cloneDeep(val[key], instanceClone);
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "is-plain-object": "^2.0.4",
+    "is-plain-object": "^5.0.0",
     "kind-of": "^6.0.2",
     "shallow-clone": "^3.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -35,6 +35,14 @@ describe('cloneDeep()', function() {
     assert.notDeepEqual(one, two);
   });
 
+  it('should deeply clone object without constructor', function() {
+    const one = Object.create(null);
+    one.a = 'b';
+    const two = clone(one);
+    two.c = 'd';
+    assert.notDeepEqual(one, two);
+  });
+
   it('should deeply clone arrays', function() {
     const one = {a: 'b'};
     const arr1 = [one];


### PR DESCRIPTION
objects created with Object.create(null) were not cloned
passing instanceClone as true was throwing an error  for those objects