### PR TITLE
Bumb kind-of version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "is-plain-object": "^5.0.0",
-    "kind-of": "^6.0.2",
+    "kind-of": "^6.0.3",
     "shallow-clone": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`kind-of` < 6.0.3 has been flagged for vulnerability: https://security.snyk.io/package/npm/kind-of

The caret ensures minor updates are allowed, but this ensures it always get the right version plus it stops referencing ^6.0.2 that can be flagged by security scans.